### PR TITLE
Add "broccoli-plugin" keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "bugs": {
     "url": "https://github.com/aaronshaf/broccoli-requirejs/issues"
   },
+  "keywords": [
+    "broccoli-plugin"
+  ],
   "homepage": "https://github.com/aaronshaf/broccoli-requirejs",
   "dependencies": {
     "broccoli-writer": "^0.1.1",


### PR DESCRIPTION
I use http://broccoliplugins.com/ to fine plugins, so I didn't immediately stumble upon your plugin. Adding the `broccoli-plugin` keyword (and probably doing a publish) will get cause this plugin to be listed.