### PR TITLE
Fix bug where cwd isn't honored.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ RequireJsFilter.prototype.write = function (readTree, destDir) {
   });
 
   return readTree(this.inputTree).then(function (srcDir) {
-    var child = fork(path.join(__dirname, 'run_optimizer.js'), {
+    var child = fork(path.join(__dirname, 'run_optimizer.js'), [], {
       cwd    : srcDir,
       silent : !filterOptions.verbose
     });


### PR DESCRIPTION
At the moment the options to `fork()` are being treated as the `args` parameter rather than `options` (see http://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options). This patch fixes that.